### PR TITLE
feat: LLM을 통한 pdf to text 기능 추가 및 main.py의 extract_text_from_pdf() 수정

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from dotenv import load_dotenv
 
 # [Import] src 폴더 내의 모듈을 불러옵니다.
 from src.toxic_detector import ToxicClauseDetector
+from src.llm_service import LLM_gemini
 
 # --- 1. 페이지 설정 ---
 st.set_page_config(
@@ -17,9 +18,12 @@ st.set_page_config(
 
 # --- 2. 헬퍼 함수들 (PDF 파싱 & 더미 데이터) ---
 
-def extract_text_from_pdf(pdf_file):
+def extract_text_from_pdf(pdf_file,api_key,model_name): 
     """PDF 파일에서 텍스트를 추출하는 함수"""
-    pass
+    pdf_file_bytes = pdf_file.read()
+    gemini = LLM_gemini(gemini_api_key=api_key, model=model_name)
+    result = gemini.pdf_to_text(pdf_file_bytes)
+    return result
 
 def get_dummy_contract_text():
     """테스트용 가상 근로계약서 텍스트"""
@@ -116,7 +120,7 @@ def main():
     
     if uploaded_file is not None:
         with st.spinner("PDF에서 텍스트를 추출하는 중..."):
-            extracted_text = extract_text_from_pdf(uploaded_file)
+            extracted_text = extract_text_from_pdf(uploaded_file,api_key_input,'gemini-2.0-flash-lite')
             if extracted_text:
                 contract_content = extracted_text
                 st.success("PDF 텍스트 추출 완료!")

--- a/src/llm_service.py
+++ b/src/llm_service.py
@@ -1,0 +1,49 @@
+from google import genai
+
+# 1. gemini 객체 만들기
+class LLM_gemini():
+    # 사용자의 API Key와 사용할 모델을 입력
+    def __init__(self, gemini_api_key, model):
+        self.GEMINI_API_KEY = gemini_api_key
+        self.model_name = model
+
+    # pdf를 text로 추출하는 함수
+    # 아직까지는 pdf를 text로 추출할 때만 gemini를 사용하기 때문에 client를 함수 내부에서 생성했다.
+    # 입력값은 pdf_bytes = st.file_uploader().read()
+    def pdf_to_text(self, pdf_file_bytes):
+        extraction_prompt = """
+        당신은 법률 문서 텍스트 추출 전문가입니다. 
+        제공된 PDF 파일의 내용을 읽고, 아래 [출력 양식]에 맞춰 텍스트만 정확하게 추출하세요.
+        
+        [규칙]
+        1. 절대 내용을 요약하거나 생략하지 마십시오. (Verbatim Extraction)
+        2. 조항의 제목과 본문은 줄바꿈으로 구분하십시오.
+        3. 각 조항 사이에는 빈 줄을 추가하십시오.
+        4. 서문(계약 당사자 정의 등)이 있다면 맨 위에 적어주십시오.
+
+        [출력 양식 예시]
+        제1조 (목적)
+        본 계약은 사용자 (주)악덕상사(이하 "갑")와...
+
+        제2조 (임금)
+        1. 월 급여는...
+        2. 위 급여에는...
+        """
+
+        client = genai.Client(api_key= self.GEMINI_API_KEY)
+        response = client.models.generate_content(
+                model=self.model_name,
+                contents=[
+                    genai.types.Part.from_bytes(data=pdf_file_bytes, mime_type="application/pdf"),
+                    extraction_prompt 
+                ]
+            )
+        return response.text
+    
+    # prompt에 맞는 텍스트를 출력하는 함수
+    # toxic_detector.py에서 필요하다.
+    def generate(self,promot):
+        result = ''
+        return result
+    
+


### PR DESCRIPTION
Gemini를 이용해서 pdf를 텍스트로 바꾸는 기능을 추가했습니다.
llm_service.py에 추가했으며 main.py의 extract_text_from_pdf()을 일부 수정했습니다.

구현 상의 이유로 gemini의 api만 가능하게 설계했습니다. 이 부분을 염두 하셨으면 좋겠습니다
다들 실행해 보고 피드백 남겨주세요.