### PR TITLE
fix: 함수이름 중복사용을 인한 재귀호출 오류 수정

### DIFF
--- a/src/law/precedent_context.py
+++ b/src/law/precedent_context.py
@@ -23,7 +23,7 @@ class PrecedentContextManager:
         self.embeddings = HuggingFaceEmbeddings(model_name=EMBEDDING_MODEL_NAME)
         # ⚠️ 참고: self.embeddings 객체를 생성할 때 네트워크 연결이 필요할 수 있습니다.
 
-    def initialize_database(self):
+    def create_database(self):
         """
         Hugging Face 데이터셋에서 판례를 다운로드하고 Document 객체로 변환합니다.
         """
@@ -95,7 +95,7 @@ class PrecedentContextManager:
         
         # 2. 신규 DB 구축
         print("📚 [초기화] 판례 데이터 신규 구축을 시작합니다...")
-        all_docs = self.initialize_database()
+        all_docs = self.create_database()
 
         if not all_docs:
             print("❌ 저장할 판례 데이터가 없어 DB 생성을 건너뜁니다.")


### PR DESCRIPTION
precedent_context.py의 PrecedentContextManager 클래스에서 다음과 같이 정의되어 있었습니다.

db생성 함수: initialize_database(self)
db로드 함수: initialize_database(self)

DB로드 함수에서 DB생성함수를 부르려는 의도와는 다르게 
initialize_database(self)내부에서 initialize_database(self)가 중복으로 사용되어 DB가 생성되지 않고 재귀호출을 하다가 오류가 발생합니다.

수정 후:
db생성 함수: create_database(self)
db로드 함수: initialize_database(self)